### PR TITLE
feat: implement tkinter gui calculator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.env
+.venv
+build/
+dist/
+*.spec

--- a/app.py
+++ b/app.py
@@ -1,0 +1,19 @@
+"""Entry point for the scientific calculator GUI application."""
+
+from __future__ import annotations
+
+import tkinter as tk
+
+from ui.main_window import MainWindow
+
+
+def main() -> None:
+    """Launch the graphical calculator interface."""
+
+    root = tk.Tk()
+    MainWindow(root)
+    root.mainloop()
+
+
+if __name__ == "__main__":
+    main()

--- a/calculator/__init__.py
+++ b/calculator/__init__.py
@@ -1,0 +1,9 @@
+"""Calculation engine and helper modules for the scientific calculator."""
+
+__all__ = [
+    "engine",
+    "basic_operations",
+    "scientific_operations",
+    "calculus_operations",
+    "exceptions",
+]

--- a/calculator/basic_operations.py
+++ b/calculator/basic_operations.py
@@ -1,0 +1,34 @@
+"""Implementations for the calculator's basic arithmetic operations."""
+
+from __future__ import annotations
+
+
+def add(lhs: float, rhs: float) -> float:
+    """Return the sum of ``lhs`` and ``rhs``."""
+
+    return lhs + rhs
+
+
+def subtract(lhs: float, rhs: float) -> float:
+    """Return the difference ``lhs - rhs``."""
+
+    return lhs - rhs
+
+
+def multiply(lhs: float, rhs: float) -> float:
+    """Return the product of ``lhs`` and ``rhs``."""
+
+    return lhs * rhs
+
+
+def divide(lhs: float, rhs: float) -> float:
+    """Return the quotient ``lhs / rhs``.
+
+    A :class:`ZeroDivisionError` is raised if ``rhs`` is zero to match the
+    behaviour expected from a traditional calculator.
+    """
+
+    if rhs == 0:
+        raise ZeroDivisionError("Division by zero is not defined.")
+
+    return lhs / rhs

--- a/calculator/calculus_operations.py
+++ b/calculator/calculus_operations.py
@@ -1,0 +1,172 @@
+"""Symbolic calculus helpers for polynomial expressions."""
+
+from __future__ import annotations
+
+import ast
+from collections import defaultdict
+
+
+def differentiate(expression: str, variable: str = "x") -> str:
+    """Return the derivative of a polynomial expression."""
+
+    polynomial = _parse_polynomial(expression, variable)
+    derivative: dict[int, float] = {}
+
+    for power, coefficient in polynomial.items():
+        if power == 0:
+            continue
+        derivative[power - 1] = derivative.get(power - 1, 0.0) + coefficient * power
+
+    return _format_polynomial(derivative, variable)
+
+
+def integrate(expression: str, variable: str = "x") -> str:
+    """Return the indefinite integral of a polynomial expression."""
+
+    polynomial = _parse_polynomial(expression, variable)
+    integral: dict[int, float] = {}
+
+    for power, coefficient in polynomial.items():
+        new_power = power + 1
+        integral[new_power] = integral.get(new_power, 0.0) + coefficient / new_power
+
+    return _format_polynomial(integral, variable)
+
+
+def _parse_polynomial(expression: str, variable: str) -> dict[int, float]:
+    if not expression.strip():
+        raise ValueError("Expression must not be empty.")
+
+    if not variable.isidentifier():
+        raise ValueError("Variable name must be a valid identifier.")
+
+    try:
+        parsed = ast.parse(expression, mode="eval")
+    except SyntaxError as exc:
+        raise ValueError(f"Unable to parse expression '{expression}'.") from exc
+
+    result = _collect_terms(parsed.body, variable)
+    cleaned = {power: coeff for power, coeff in result.items() if coeff != 0}
+
+    if not cleaned:
+        return {0: 0.0}
+
+    return cleaned
+
+
+def _collect_terms(node: ast.AST, variable: str) -> dict[int, float]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        return {0: float(node.value)}
+
+    if isinstance(node, ast.Name):
+        if node.id != variable:
+            raise ValueError(f"Unsupported variable '{node.id}'.")
+        return {1: 1.0}
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        terms = _collect_terms(node.operand, variable)
+        return {power: -coeff for power, coeff in terms.items()}
+
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.UAdd):
+        return _collect_terms(node.operand, variable)
+
+    if isinstance(node, ast.BinOp):
+        if isinstance(node.op, (ast.Add, ast.Sub)):
+            left = _collect_terms(node.left, variable)
+            right = _collect_terms(node.right, variable)
+            if isinstance(node.op, ast.Sub):
+                right = {power: -coeff for power, coeff in right.items()}
+            return _merge_terms(left, right)
+
+        if isinstance(node.op, ast.Mult):
+            left = _collect_terms(node.left, variable)
+            right = _collect_terms(node.right, variable)
+            if _is_constant(left):
+                return {power: _get_constant(left) * coeff for power, coeff in right.items()}
+            if _is_constant(right):
+                return {power: _get_constant(right) * coeff for power, coeff in left.items()}
+            raise ValueError("Polynomial multiplication must involve a constant factor.")
+
+        if isinstance(node.op, ast.Pow):
+            base = node.left
+            exponent = node.right
+            if not isinstance(base, ast.Name) or base.id != variable:
+                raise ValueError("Only powers of the differentiation variable are supported.")
+            if not isinstance(exponent, ast.Constant) or not isinstance(
+                exponent.value, (int, float)
+            ):
+                raise ValueError("Polynomial exponents must be numeric constants.")
+            power = int(exponent.value)
+            if exponent.value != power or power < 0:
+                raise ValueError("Polynomial exponents must be non-negative integers.")
+            return {power: 1.0}
+
+    raise ValueError("Unsupported expression for polynomial calculus operations.")
+
+
+def _merge_terms(left: dict[int, float], right: dict[int, float]) -> dict[int, float]:
+    result: dict[int, float] = defaultdict(float)
+    for power, coeff in left.items():
+        result[power] += coeff
+    for power, coeff in right.items():
+        result[power] += coeff
+    return dict(result)
+
+
+def _is_constant(terms: dict[int, float]) -> bool:
+    return len(terms) == 1 and 0 in terms
+
+
+def _get_constant(terms: dict[int, float]) -> float:
+    return terms[0]
+
+
+def _format_polynomial(terms: dict[int, float], variable: str) -> str:
+    if not terms:
+        return "0"
+
+    parts: list[str] = []
+    for power in sorted(terms.keys(), reverse=True):
+        coeff = terms[power]
+        if coeff == 0:
+            continue
+
+        coeff_str = _format_number(coeff)
+
+        if power == 0:
+            term = coeff_str
+        elif power == 1:
+            if coeff == 1:
+                term = variable
+            elif coeff == -1:
+                term = f"-{variable}"
+            else:
+                term = f"{coeff_str}*{variable}"
+        else:
+            base = f"{variable}**{power}"
+            if coeff == 1:
+                term = base
+            elif coeff == -1:
+                term = f"-{base}"
+            else:
+                term = f"{coeff_str}*{base}"
+
+        parts.append(term)
+
+    if not parts:
+        return "0"
+
+    formatted = parts[0]
+    for term in parts[1:]:
+        if term.startswith("-"):
+            formatted += f" - {term[1:]}"
+        else:
+            formatted += f" + {term}"
+
+    return formatted
+
+
+def _format_number(value: float) -> str:
+    if value == int(value):
+        return str(int(value))
+    return str(value)

--- a/calculator/engine.py
+++ b/calculator/engine.py
@@ -1,0 +1,152 @@
+"""Core calculator engine implementation."""
+
+from __future__ import annotations
+
+import ast
+import math
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Operation(Protocol):
+    """Protocol representing a calculator operation."""
+
+    name: str
+
+    def evaluate(self, *operands: float) -> float:
+        """Execute the operation with the provided operands."""
+
+
+@dataclass
+class EngineConfig:
+    """Configuration options controlling expression evaluation."""
+
+    angle_unit: str = "radian"
+    precision: int = 8
+
+    def __post_init__(self) -> None:
+        if self.angle_unit not in {"radian", "degree"}:
+            raise ValueError("angle_unit must be either 'radian' or 'degree'.")
+
+        if self.precision <= 0:
+            raise ValueError("precision must be a positive integer.")
+
+
+class CalculatorEngine:
+    """Evaluate mathematical expressions in a controlled environment."""
+
+    def __init__(self, config: EngineConfig | None = None) -> None:
+        self.config = config or EngineConfig()
+
+    def _convert_angle(self, value: float) -> float:
+        if self.config.angle_unit == "degree":
+            return math.radians(value)
+        return value
+
+    def _eval_function(self, name: str, args: list[float]) -> float:
+        if name == "sin":
+            return math.sin(self._convert_angle(_require_args(name, args, 1)))
+        if name == "cos":
+            return math.cos(self._convert_angle(_require_args(name, args, 1)))
+        if name == "tan":
+            angle = self._convert_angle(_require_args(name, args, 1))
+            return math.tan(angle)
+        if name in {"log", "ln"}:
+            if len(args) == 1:
+                value = args[0]
+                base = math.e if name == "ln" else 10.0
+            elif len(args) == 2:
+                value, base = args
+            else:
+                raise ValueError(f"{name} expects one or two arguments.")
+
+            if value <= 0:
+                raise ValueError("Logarithm is only defined for positive values.")
+            if base <= 0 or base == 1:
+                raise ValueError("Logarithm base must be positive and not equal to 1.")
+            return math.log(value, base)
+        if name == "exp":
+            return math.exp(_require_args(name, args, 1))
+        if name == "sqrt":
+            value = _require_args(name, args, 1)
+            if value < 0:
+                raise ValueError("Square root is only defined for non-negative values.")
+            return math.sqrt(value)
+
+        raise ValueError(f"Unsupported function '{name}'.")
+
+    def _eval(self, node: ast.AST) -> float:
+        if isinstance(node, ast.Expression):
+            return self._eval(node.body)
+
+        if isinstance(node, ast.Constant):
+            if isinstance(node.value, (int, float)):
+                return float(node.value)
+            raise ValueError("Unsupported constant type.")
+
+        if isinstance(node, ast.Name):
+            if node.id == "pi":
+                return math.pi
+            if node.id == "e":
+                return math.e
+            raise ValueError(f"Unknown identifier '{node.id}'.")
+
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+            return -self._eval(node.operand)
+
+        if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.UAdd):
+            return self._eval(node.operand)
+
+        if isinstance(node, ast.BinOp):
+            left = self._eval(node.left)
+            right = self._eval(node.right)
+
+            if isinstance(node.op, ast.Add):
+                return left + right
+            if isinstance(node.op, ast.Sub):
+                return left - right
+            if isinstance(node.op, ast.Mult):
+                return left * right
+            if isinstance(node.op, ast.Div):
+                if right == 0:
+                    raise ZeroDivisionError("Division by zero is not defined.")
+                return left / right
+            if isinstance(node.op, ast.Pow):
+                return math.pow(left, right)
+
+            raise ValueError("Unsupported binary operation.")
+
+        if isinstance(node, ast.Call):
+            if not isinstance(node.func, ast.Name):
+                raise ValueError("Unsupported function call.")
+            name = node.func.id
+            args = [self._eval(arg) for arg in node.args]
+            return self._eval_function(name, args)
+
+        raise ValueError("Unsupported expression component.")
+
+    def evaluate(self, expression: str) -> float:
+        """Evaluate ``expression`` and return the resulting float."""
+
+        if not expression or not expression.strip():
+            raise ValueError("Expression must not be empty.")
+
+        try:
+            parsed = ast.parse(expression, mode="eval")
+        except SyntaxError as exc:
+            raise ValueError(f"Unable to parse expression '{expression}'.") from exc
+
+        result = self._eval(parsed)
+
+        if not math.isfinite(result):
+            raise ZeroDivisionError("Expression evaluates to an undefined value.")
+
+        # ``round`` behaves predictably for both integers and floats and gives us
+        # a precision measured in decimal places, which is what users expect.
+        return round(result, self.config.precision)
+
+
+def _require_args(name: str, args: list[float], expected: int) -> float:
+    if len(args) != expected:
+        raise ValueError(f"{name} expects {expected} argument(s).")
+    return args[0]

--- a/calculator/exceptions.py
+++ b/calculator/exceptions.py
@@ -1,0 +1,15 @@
+"""Custom exceptions for the calculator application."""
+
+from __future__ import annotations
+
+
+class CalculatorError(Exception):
+    """Base class for calculator-specific exceptions."""
+
+
+class InvalidExpressionError(CalculatorError):
+    """Raised when the engine fails to parse or evaluate an expression."""
+
+
+class OperationNotSupportedError(CalculatorError):
+    """Raised when a requested operation has not been implemented."""

--- a/calculator/scientific_operations.py
+++ b/calculator/scientific_operations.py
@@ -1,0 +1,58 @@
+"""Scientific calculator functions used throughout the application."""
+
+from __future__ import annotations
+
+import math
+
+_SUPPORTED_ANGLE_UNITS = {"radian", "degree"}
+
+
+def _normalize_angle(value: float, angle_unit: str) -> float:
+    if angle_unit not in _SUPPORTED_ANGLE_UNITS:
+        raise ValueError(f"Unsupported angle unit: {angle_unit}")
+
+    if angle_unit == "degree":
+        return math.radians(value)
+
+    return value
+
+
+def sine(value: float, *, angle_unit: str = "radian") -> float:
+    """Return the sine of ``value`` using the requested ``angle_unit``."""
+
+    return math.sin(_normalize_angle(value, angle_unit))
+
+
+def cosine(value: float, *, angle_unit: str = "radian") -> float:
+    """Return the cosine of ``value`` using the requested ``angle_unit``."""
+
+    return math.cos(_normalize_angle(value, angle_unit))
+
+
+def tangent(value: float, *, angle_unit: str = "radian") -> float:
+    """Return the tangent of ``value`` using the requested ``angle_unit``."""
+
+    angle = _normalize_angle(value, angle_unit)
+    return math.tan(angle)
+
+
+def logarithm(value: float, base: float = 10.0) -> float:
+    """Return ``log_base(value)``.
+
+    ``value`` must be positive. ``base`` must be positive and different from 1.
+    A :class:`ValueError` is raised when those constraints are not met.
+    """
+
+    if value <= 0:
+        raise ValueError("Logarithm is only defined for positive values.")
+
+    if base <= 0 or base == 1:
+        raise ValueError("Logarithm base must be positive and not equal to 1.")
+
+    return math.log(value, base)
+
+
+def exponential(value: float) -> float:
+    """Return ``e`` raised to ``value``."""
+
+    return math.exp(value)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,27 @@
+# Project Overview
+
+## Architecture summary
+
+The calculator is organised into three primary layers:
+
+1. **Calculation engine (`calculator/`)** – Contains the AST-driven
+   :class:`~calculator.engine.CalculatorEngine` plus helper modules for
+   arithmetic, scientific functions, and polynomial calculus operations.
+2. **User interface (`ui/`)** – Provides the Tkinter-based
+   :class:`~ui.main_window.MainWindow` and supporting widgets that drive the
+   graphical application.
+3. **Application entry point (`app.py`)** – Creates the Tk root window, instals
+   the main UI frame, and starts the event loop.
+
+Automated tests in ``tests/`` exercise the calculation modules, and the
+documentation in ``docs/`` records the design and usage details. Packaging
+assets will be added under ``setup/`` in a later phase.
+
+## Key features
+
+* Safe evaluation of arithmetic expressions with configurable precision.
+* Trigonometric, logarithmic, exponential, and square-root helpers with
+  validation and degree/radian support.
+* Polynomial differentiation and integration utilities for a single variable.
+* Desktop GUI with keypad, scientific function buttons, angle-unit selector,
+  precision control, and a calculus panel.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,0 +1,34 @@
+# User Guide
+
+## Launching the application
+
+Run the following command from the project root to open the calculator window:
+
+```
+python app.py
+```
+
+The program is built with ``tkinter`` and does not require any third-party
+packages.
+
+## Calculator panel
+
+* Enter numbers with the on-screen keypad or your keyboard.
+* Use ``sin``, ``cos``, ``tan``, ``log``, ``ln``, ``exp``, and ``sqrt`` buttons to
+  insert function calls – the opening parenthesis is added automatically.
+* ``^`` inserts an exponent operator. Expressions typed with ``^`` are converted
+  to Python's ``**`` before evaluation.
+* ``Ans`` pastes the most recent result into the expression field.
+* Adjust the angle unit (radians or degrees) and decimal precision using the
+  controls above the keypad.
+* Press ``=`` or hit the Enter key to evaluate the current expression. Results
+  appear in the display below the entry field.
+
+## Calculus panel
+
+* Provide a polynomial expression (for example ``3*x^2 + 2*x - 5``) and the
+  variable name (default: ``x``).
+* Click **Differentiate** to compute the derivative or **Integrate** for the
+  indefinite integral.
+* Any validation errors are displayed using a pop-up dialog; correct the input
+  and try again.

--- a/readme.md
+++ b/readme.md
@@ -1,1 +1,42 @@
-empty
+# Scientific Calculator Project
+
+This repository hosts a Python-based scientific calculator that now includes
+working arithmetic, scientific, polynomial calculus, and desktop GUI
+functionality. The implementation uses Python's standard-library ``tkinter``
+toolkit so the application can run without additional dependencies while still
+providing an intuitive interface for everyday use.
+
+## Current Structure
+- `app.py` – Entry point for the Tkinter GUI application.
+- `calculator/` – Package containing the calculation engine and operation
+  modules.
+- `ui/` – Package providing the Tkinter main window and reusable widgets.
+- `tests/` – Automated regression tests covering the current functionality.
+- `docs/` – Documentation placeholders.
+- `setup/` – Future distribution/build scripts.
+- `requirements.txt` – Python dependencies for upcoming implementation phases.
+
+## Available Features
+
+- **Basic arithmetic**: addition, subtraction, multiplication, and division
+  helpers with input validation.
+- **Scientific functions**: trigonometry with configurable angle units,
+  exponential, and logarithmic operations.
+- **Polynomial calculus**: analytic differentiation and integration for
+  single-variable polynomials.
+- **Expression engine**: safe AST-based evaluator that supports arithmetic,
+  scientific functions, configurable precision, and angle units.
+- **Desktop GUI**: Tkinter interface with keypad, scientific function buttons,
+  configurable angle units, precision control, and built-in calculus helpers.
+
+Further packaging work remains for subsequent steps of the plan.
+
+## Running the calculator
+
+```
+python app.py
+```
+
+Launching the application opens the calculator window. Enter expressions using
+the keypad or your keyboard, press ``=`` to evaluate, and use the calculus
+panel at the bottom to differentiate or integrate polynomial expressions.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# The calculator currently relies only on the Python standard library.
+# This file is kept to make it easy to add third-party packages in later
+# development phases (for example when packaging the application).

--- a/setup/README.md
+++ b/setup/README.md
@@ -1,0 +1,4 @@
+# Setup Scripts (Placeholder)
+
+This directory will contain packaging and distribution scripts, such as
+PyInstaller configurations, in later development steps.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package initialization for the calculator application."""

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,26 @@
+"""Tests for the basic arithmetic helpers."""
+
+import pytest
+
+from calculator import basic_operations as ops
+
+
+def test_add() -> None:
+    assert ops.add(2, 3) == 5
+
+
+def test_subtract() -> None:
+    assert ops.subtract(10, 4) == 6
+
+
+def test_multiply() -> None:
+    assert ops.multiply(7, -2) == -14
+
+
+def test_divide() -> None:
+    assert ops.divide(9, 3) == 3
+
+
+def test_divide_by_zero() -> None:
+    with pytest.raises(ZeroDivisionError):
+        ops.divide(1, 0)

--- a/tests/test_calculus.py
+++ b/tests/test_calculus.py
@@ -1,0 +1,21 @@
+"""Tests for calculus helper functions."""
+
+import pytest
+
+from calculator import calculus_operations as ops
+
+
+def test_differentiate_polynomial() -> None:
+    assert ops.differentiate("x**3 + 2*x", "x") == "3*x**2 + 2"
+
+
+def test_integrate_polynomial() -> None:
+    assert ops.integrate("3*x**2", "x") == "x**3"
+
+
+def test_invalid_expression() -> None:
+    with pytest.raises(ValueError):
+        ops.differentiate("", "x")
+
+    with pytest.raises(ValueError):
+        ops.integrate("sin(y)", "1x")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,48 @@
+"""Tests for the calculator engine."""
+
+import math
+
+import pytest
+
+from calculator.engine import CalculatorEngine, EngineConfig
+
+
+def test_basic_expression_evaluation() -> None:
+    engine = CalculatorEngine()
+    assert engine.evaluate("2 + 3 * 4") == 14
+
+
+def test_trigonometric_expression_in_radians() -> None:
+    engine = CalculatorEngine()
+    result = engine.evaluate("sin(pi/2)")
+    assert pytest.approx(result, rel=1e-8) == 1.0
+
+
+def test_trigonometric_expression_in_degrees() -> None:
+    engine = CalculatorEngine(EngineConfig(angle_unit="degree"))
+    result = engine.evaluate("sin(30)")
+    assert pytest.approx(result, rel=1e-8) == 0.5
+
+
+def test_logarithm_with_base() -> None:
+    engine = CalculatorEngine()
+    result = engine.evaluate("log(100, 10)")
+    assert pytest.approx(result, rel=1e-8) == 2
+
+
+def test_invalid_expression_raises_value_error() -> None:
+    engine = CalculatorEngine()
+    with pytest.raises(ValueError):
+        engine.evaluate("sin(x)")
+
+
+def test_division_by_zero_raises() -> None:
+    engine = CalculatorEngine()
+    with pytest.raises(ZeroDivisionError):
+        engine.evaluate("1 / 0")
+
+
+def test_precision_configuration() -> None:
+    engine = CalculatorEngine(EngineConfig(precision=4))
+    result = engine.evaluate("1 / 3")
+    assert math.isclose(result, 0.3333, rel_tol=1e-4)

--- a/tests/test_scientific.py
+++ b/tests/test_scientific.py
@@ -1,0 +1,42 @@
+"""Tests for the scientific operation helpers."""
+
+import math
+
+import pytest
+
+from calculator import scientific_operations as ops
+
+
+def test_trigonometry_in_radians() -> None:
+    assert pytest.approx(ops.sine(math.pi / 2)) == 1
+    assert pytest.approx(ops.cosine(0)) == 1
+
+
+def test_trigonometry_in_degrees() -> None:
+    assert pytest.approx(ops.sine(30, angle_unit="degree")) == 0.5
+    assert pytest.approx(ops.cosine(60, angle_unit="degree")) == 0.5
+
+
+def test_unsupported_angle_unit() -> None:
+    with pytest.raises(ValueError):
+        ops.sine(10, angle_unit="gradian")
+
+
+def test_tangent() -> None:
+    assert pytest.approx(ops.tangent(math.pi / 4)) == pytest.approx(1)
+
+
+def test_logarithm() -> None:
+    assert pytest.approx(ops.logarithm(100, base=10)) == 2
+
+
+def test_logarithm_invalid_arguments() -> None:
+    with pytest.raises(ValueError):
+        ops.logarithm(-1)
+
+    with pytest.raises(ValueError):
+        ops.logarithm(10, base=1)
+
+
+def test_exponential() -> None:
+    assert pytest.approx(ops.exponential(1)) == math.e

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,3 @@
+"""UI package initialization for the calculator application."""
+
+__all__ = ["main_window", "widgets"]

--- a/ui/main_window.py
+++ b/ui/main_window.py
@@ -1,0 +1,326 @@
+"""Tkinter-based main window for the scientific calculator."""
+
+from __future__ import annotations
+
+import functools
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Callable
+
+from calculator.calculus_operations import differentiate, integrate
+from calculator.engine import CalculatorEngine, EngineConfig
+from ui.widgets import ButtonPad
+
+
+class MainWindow(ttk.Frame):
+    """Build and manage the calculator interface."""
+
+    def __init__(self, master: tk.Tk) -> None:
+        super().__init__(master, padding=12)
+
+        self._root = master
+        self._root.title("Scientific Calculator")
+        self._root.geometry("520x640")
+        self._root.minsize(480, 560)
+        self._root.rowconfigure(0, weight=1)
+        self._root.columnconfigure(0, weight=1)
+
+        self.grid(sticky="nsew")
+        self.rowconfigure(0, weight=1)
+        self.columnconfigure(0, weight=1)
+
+        self.engine = CalculatorEngine()
+        self.expression_var = tk.StringVar()
+        self.result_var = tk.StringVar(value="0")
+        self.angle_unit_var = tk.StringVar(value=self.engine.config.angle_unit)
+        self.precision_var = tk.StringVar(value=str(self.engine.config.precision))
+        self.calculus_expression_var = tk.StringVar()
+        self.calculus_variable_var = tk.StringVar(value="x")
+        self.calculus_result_var = tk.StringVar(value="")
+
+        self._build_calculator_panel()
+        self._build_calculus_panel()
+
+        self._root.bind("<Return>", self._handle_return)
+
+    # ------------------------------------------------------------------
+    # Layout builders
+    # ------------------------------------------------------------------
+    def _build_calculator_panel(self) -> None:
+        calc_frame = ttk.LabelFrame(self, text="Calculator")
+        calc_frame.grid(row=0, column=0, sticky="nsew")
+        calc_frame.columnconfigure(0, weight=3)
+        calc_frame.columnconfigure(1, weight=2)
+        calc_frame.rowconfigure(1, weight=1)
+
+        display_frame = ttk.Frame(calc_frame)
+        display_frame.grid(row=0, column=0, columnspan=2, sticky="ew")
+        display_frame.columnconfigure(0, weight=1)
+
+        expression_entry = ttk.Entry(
+            display_frame,
+            textvariable=self.expression_var,
+            font=("TkDefaultFont", 14),
+        )
+        expression_entry.grid(row=0, column=0, sticky="ew", padx=4, pady=(6, 2))
+        expression_entry.focus_set()
+
+        result_label = ttk.Label(
+            display_frame,
+            textvariable=self.result_var,
+            font=("TkDefaultFont", 14),
+            anchor="e",
+        )
+        result_label.grid(row=1, column=0, sticky="ew", padx=4, pady=(0, 8))
+
+        options_frame = ttk.Frame(display_frame)
+        options_frame.grid(row=2, column=0, sticky="ew", padx=4, pady=(0, 10))
+        options_frame.columnconfigure(3, weight=1)
+
+        ttk.Label(options_frame, text="Angle unit:").grid(row=0, column=0, sticky="w")
+        angle_menu = ttk.OptionMenu(
+            options_frame,
+            self.angle_unit_var,
+            self.angle_unit_var.get(),
+            "radian",
+            "degree",
+            command=self._on_angle_unit_change,
+        )
+        angle_menu.grid(row=0, column=1, sticky="w", padx=(6, 12))
+
+        ttk.Label(options_frame, text="Precision:").grid(row=0, column=2, sticky="w")
+        precision_entry = ttk.Entry(
+            options_frame,
+            textvariable=self.precision_var,
+            width=4,
+            justify="center",
+        )
+        precision_entry.grid(row=0, column=3, sticky="w")
+
+        keypad_layout = [
+            [
+                ("C", self.clear_expression),
+                ("⌫", self.backspace),
+                ("(", functools.partial(self.append_text, "(")),
+                (")", functools.partial(self.append_text, ")")),
+            ],
+            [
+                ("7", functools.partial(self.append_text, "7")),
+                ("8", functools.partial(self.append_text, "8")),
+                ("9", functools.partial(self.append_text, "9")),
+                ("/", functools.partial(self.append_text, "/")),
+            ],
+            [
+                ("4", functools.partial(self.append_text, "4")),
+                ("5", functools.partial(self.append_text, "5")),
+                ("6", functools.partial(self.append_text, "6")),
+                ("*", functools.partial(self.append_text, "*")),
+            ],
+            [
+                ("1", functools.partial(self.append_text, "1")),
+                ("2", functools.partial(self.append_text, "2")),
+                ("3", functools.partial(self.append_text, "3")),
+                ("-", functools.partial(self.append_text, "-")),
+            ],
+            [
+                ("0", functools.partial(self.append_text, "0")),
+                (".", functools.partial(self.append_text, ".")),
+                ("+", functools.partial(self.append_text, "+")),
+                ("=", self.evaluate_expression),
+            ],
+            [
+                ("^", functools.partial(self.append_text, "^")),
+                ("pi", functools.partial(self.append_text, "pi")),
+                ("e", functools.partial(self.append_text, "e")),
+                ("Ans", self.insert_result),
+            ],
+        ]
+
+        keypad = ButtonPad(calc_frame, layout=keypad_layout)
+        keypad.grid(row=1, column=0, sticky="nsew", padx=(6, 4), pady=(0, 10))
+
+        functions_frame = ttk.Frame(calc_frame)
+        functions_frame.grid(row=1, column=1, sticky="nsew", padx=(4, 6), pady=(0, 10))
+        functions_frame.columnconfigure(0, weight=1)
+
+        function_buttons = [
+            ("sin", functools.partial(self.append_function, "sin")),
+            ("cos", functools.partial(self.append_function, "cos")),
+            ("tan", functools.partial(self.append_function, "tan")),
+            ("log", functools.partial(self.append_function, "log")),
+            ("ln", functools.partial(self.append_function, "ln")),
+            ("exp", functools.partial(self.append_function, "exp")),
+            ("sqrt", functools.partial(self.append_function, "sqrt")),
+        ]
+
+        for index, (label, command) in enumerate(function_buttons):
+            functions_frame.rowconfigure(index, weight=1)
+            button = ttk.Button(functions_frame, text=label, command=command)
+            button.grid(row=index, column=0, sticky="nsew", padx=2, pady=2)
+
+    def _build_calculus_panel(self) -> None:
+        calculus_frame = ttk.LabelFrame(self, text="Polynomial calculus")
+        calculus_frame.grid(row=1, column=0, sticky="ew", pady=(12, 0))
+        calculus_frame.columnconfigure(1, weight=1)
+        calculus_frame.columnconfigure(2, weight=1)
+
+        ttk.Label(calculus_frame, text="Expression:").grid(
+            row=0,
+            column=0,
+            sticky="w",
+            padx=6,
+            pady=(6, 2),
+        )
+        expression_entry = ttk.Entry(
+            calculus_frame,
+            textvariable=self.calculus_expression_var,
+        )
+        expression_entry.grid(row=0, column=1, columnspan=2, sticky="ew", padx=6, pady=(6, 2))
+
+        ttk.Label(calculus_frame, text="Variable:").grid(
+            row=1,
+            column=0,
+            sticky="w",
+            padx=6,
+            pady=(0, 6),
+        )
+        variable_entry = ttk.Entry(
+            calculus_frame,
+            textvariable=self.calculus_variable_var,
+            width=6,
+        )
+        variable_entry.grid(row=1, column=1, sticky="w", padx=(6, 0), pady=(0, 6))
+
+        actions_frame = ttk.Frame(calculus_frame)
+        actions_frame.grid(row=1, column=2, sticky="e", padx=6, pady=(0, 6))
+
+        differentiate_button = ttk.Button(
+            actions_frame,
+            text="Differentiate",
+            command=self.differentiate_expression,
+        )
+        differentiate_button.pack(side="left", padx=(0, 6))
+
+        integrate_button = ttk.Button(
+            actions_frame,
+            text="Integrate",
+            command=self.integrate_expression,
+        )
+        integrate_button.pack(side="left")
+
+        ttk.Label(calculus_frame, text="Result:").grid(
+            row=2,
+            column=0,
+            sticky="nw",
+            padx=6,
+            pady=(0, 8),
+        )
+        calculus_result = ttk.Label(
+            calculus_frame,
+            textvariable=self.calculus_result_var,
+            wraplength=360,
+            justify="left",
+        )
+        calculus_result.grid(row=2, column=1, columnspan=2, sticky="ew", padx=6, pady=(0, 8))
+
+    # ------------------------------------------------------------------
+    # Calculator actions
+    # ------------------------------------------------------------------
+    def append_text(self, text: str) -> None:
+        self.expression_var.set(self.expression_var.get() + text)
+
+    def append_function(self, name: str) -> None:
+        self.append_text(f"{name}(")
+
+    def clear_expression(self) -> None:
+        self.expression_var.set("")
+        self.result_var.set("0")
+
+    def insert_result(self) -> None:
+        self.append_text(self.result_var.get())
+
+    def backspace(self) -> None:
+        current = self.expression_var.get()
+        if current:
+            self.expression_var.set(current[:-1])
+
+    def evaluate_expression(self) -> None:
+        expression = self.expression_var.get().strip()
+        if not expression:
+            self.result_var.set("0")
+            return
+
+        normalized_expression = expression.replace("^", "**")
+
+        try:
+            precision = int(self.precision_var.get())
+        except (tk.TclError, ValueError):
+            self._show_error("Precision must be a positive integer.")
+            return
+
+        if precision <= 0:
+            self._show_error("Precision must be a positive integer.")
+            return
+
+        try:
+            config = EngineConfig(
+                angle_unit=self.angle_unit_var.get(),
+                precision=precision,
+            )
+        except ValueError as exc:
+            self._show_error(str(exc))
+            return
+
+        self.engine.config = config
+
+        try:
+            result = self.engine.evaluate(normalized_expression)
+        except Exception as exc:  # pragma: no cover - GUI error feedback
+            self._show_error(str(exc))
+            return
+
+        self.result_var.set(str(result))
+        self.expression_var.set(str(result))
+
+    # ------------------------------------------------------------------
+    # Calculus actions
+    # ------------------------------------------------------------------
+    def differentiate_expression(self) -> None:
+        self._run_calculus_operation(differentiate, "Differentiation error")
+
+    def integrate_expression(self) -> None:
+        self._run_calculus_operation(integrate, "Integration error")
+
+    def _run_calculus_operation(
+        self,
+        operation: Callable[[str, str], str],
+        title: str,
+    ) -> None:
+        expression = self.calculus_expression_var.get().strip()
+        variable = self.calculus_variable_var.get().strip() or "x"
+
+        if not expression:
+            self._show_error("Please provide a polynomial expression to evaluate.", title=title)
+            return
+
+        try:
+            result = operation(expression, variable)
+        except ValueError as exc:
+            self._show_error(str(exc), title=title)
+            self.calculus_result_var.set("")
+            return
+
+        self.calculus_result_var.set(result)
+
+    # ------------------------------------------------------------------
+    # Event handlers and helpers
+    # ------------------------------------------------------------------
+    def _handle_return(self, _event: tk.Event[tk.Misc]) -> None:
+        self.evaluate_expression()
+
+    def _on_angle_unit_change(self, _value: str) -> None:
+        # Validation is deferred to ``EngineConfig`` during evaluation.
+        pass
+
+    def _show_error(self, message: str, *, title: str = "Error") -> None:
+        messagebox.showerror(title, message, parent=self)

--- a/ui/widgets.py
+++ b/ui/widgets.py
@@ -1,0 +1,46 @@
+"""Reusable custom widgets for the calculator GUI."""
+
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import ttk
+from typing import Callable, Sequence
+
+
+ButtonSpec = tuple[str, Callable[[], None]]
+
+
+class ButtonPad(ttk.Frame):
+    """Grid of buttons used for the calculator keypad."""
+
+    def __init__(
+        self,
+        master: tk.Misc,
+        *,
+        layout: Sequence[Sequence[ButtonSpec]],
+        padding: int = 4,
+    ) -> None:
+        super().__init__(master, padding=padding)
+        self._build(layout)
+
+    def _build(self, layout: Sequence[Sequence[ButtonSpec]]) -> None:
+        if not layout:
+            return
+
+        max_columns = max(len(row) for row in layout)
+
+        for row_index, row in enumerate(layout):
+            self.rowconfigure(row_index, weight=1)
+            for column_index, (label, command) in enumerate(row):
+                self.columnconfigure(column_index, weight=1)
+                button = ttk.Button(self, text=label, command=command)
+                button.grid(
+                    row=row_index,
+                    column=column_index,
+                    sticky="nsew",
+                    padx=2,
+                    pady=2,
+                )
+
+        for column_index in range(max_columns):
+            self.columnconfigure(column_index, weight=1)


### PR DESCRIPTION
## Summary
- replace the placeholder entry point with a Tkinter bootstrap for launching the calculator GUI
- implement the main window with keypad, scientific function buttons, angle/precision controls, and a calculus helper panel
- add a reusable button pad widget and refresh the documentation and requirements to reflect the GUI implementation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4a052a820832ba38d35dfd803f5a1